### PR TITLE
Remove IS_OFFLINE

### DIFF
--- a/src/ServerlessOffline.js
+++ b/src/ServerlessOffline.js
@@ -165,9 +165,6 @@ module.exports = class ServerlessOffline {
 
     this._verifyServerlessVersionCompatibility();
 
-    // Some users would like to know their environment outside of the handler
-    process.env.IS_OFFLINE = true;
-
     return Promise.resolve(this._buildServer())
       .then(() => this.apiGateway._listen())
       .then(() => this.hasWebsocketRoutes && this.apiGatewayWebSocket._listen())
@@ -210,7 +207,6 @@ module.exports = class ServerlessOffline {
     const command = this.options.exec;
     const options = {
       env: Object.assign(
-        { IS_OFFLINE: true },
         this.service.provider.environment,
         this.originalEnvironment,
       ),


### PR DESCRIPTION
User forked serverless offline where we've removed the IS_OFFLINE injection. This is because it was causing issues in our docker containers, where we want to inject only IS_DOCKER. Injecting both IS_DOCKER and IS_OFFLINE meant that we couldn't pick the dependencies we needed for the execution context. Serverless offline has removed this env var in v6 (because they want to match AWS behavior and they saw if you need it you can explicitly set yourself) but that still in alpha atm hence the fork.
 
Once v6 is out and stable we can delete our fork.